### PR TITLE
Revert "Substitute [yyyy] and [name of copyright owner]"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2015 Google Inc.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Reverts google/gtfs-realtime-bindings#5

It is erroneous change, the [yyyy] and [name of copyright owner] should stay unsubstituted in this file.