### PR TITLE
Update example code

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -40,7 +40,7 @@ var requestSettings = {
 };
 request(requestSettings, function (error, response, body) {
   if (!error && response.statusCode == 200) {
-    var feed = GtfsRealtimeBindings.transit_realtime.FeedMessage.decode(body);
+    var feed = GtfsRealtimeBindings.FeedMessage.decode(body);
     feed.entity.forEach(function(entity) {
       if (entity.trip_update) {
         console.log(entity.trip_update);


### PR DESCRIPTION
Updating example code to match what's provided in the docs at https://developers.google.com/transit/gtfs-realtime/examples/nodejs-sample . GtfsRealtimeBindings.transit_realtime throws an error but GtfsRealtimeBindings.FeedMessage works