### PR TITLE
updating protobufjs dependency version to fix npm security vulnerabil…

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -22,7 +22,7 @@
         "node >= 0.10.0"
     ],
     "dependencies": {
-        "protobufjs": "6.7.3"
+        "protobufjs": "6.8.6"
     },
     "devDependencies": {
         "mocha": "1.19.0",


### PR DESCRIPTION
npm audit reports that the current version of protobufjs contains a security vulnerability. 
This PR updates the version of protobufjs in package.json from `6.7.3` to `6.8.6`. All unit tests still pass.